### PR TITLE
fix: GHCR lowercase repository

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,10 +13,12 @@ jobs:
         fetch-depth: 0
     - name: Set environment variables
       run: ./build/ci/set_environment.sh
+      env:
+        GIT_REPOSITORY: ${{ github.repository }}
     - name: Build chart
       run: ./build/chart.sh
       env:
-        IMAGE_REPOSITORY: ghcr.io/${{ github.repository }}
+        IMAGE_REPOSITORY: ghcr.io/${{ env.GIT_REPOSITORY_LOWER }}
     - name: Draft release
       id: draft_release
       uses: actions/create-release@v1
@@ -41,7 +43,7 @@ jobs:
       uses: docker/build-push-action@v1
       with:
         registry: ghcr.io
-        repository: ${{ github.repository }}
+        repository: ${{ env.GIT_REPOSITORY_LOWER }}
         tags: ${{ env.IMAGE_TAG }}
         labels: >-
           org.opencontainers.image.version=${{ env.VERSION }},

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,11 +14,11 @@ jobs:
     - name: Set environment variables
       run: ./build/ci/set_environment.sh
       env:
-        GIT_REPOSITORY: ${{ github.repository }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
     - name: Build chart
       run: ./build/chart.sh
       env:
-        IMAGE_REPOSITORY: ghcr.io/${{ env.GIT_REPOSITORY_LOWER }}
+        IMAGE_REPOSITORY: ghcr.io/${{ env.GITHUB_REPOSITORY_LOWER }}
     - name: Draft release
       id: draft_release
       uses: actions/create-release@v1
@@ -43,7 +43,7 @@ jobs:
       uses: docker/build-push-action@v1
       with:
         registry: ghcr.io
-        repository: ${{ env.GIT_REPOSITORY_LOWER }}
+        repository: ${{ env.GITHUB_REPOSITORY_LOWER }}
         tags: ${{ env.IMAGE_TAG }}
         labels: >-
           org.opencontainers.image.version=${{ env.VERSION }},

--- a/build/ci/set_environment.sh
+++ b/build/ci/set_environment.sh
@@ -31,7 +31,7 @@ else
 fi
 git_tag="v${version}"
 
-git_repository_lower=$(echo "${GIT_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
+git_repository_lower="${GIT_REPOSITORY,,}"
 
 echo "::set-env name=VERSION::${version}"
 echo "VERSION::${version}"

--- a/build/ci/set_environment.sh
+++ b/build/ci/set_environment.sh
@@ -31,13 +31,13 @@ else
 fi
 git_tag="v${version}"
 
-git_repository_lower="${GIT_REPOSITORY,,}"
+github_repository_lower="${GITHUB_REPOSITORY,,}"
 
 echo "::set-env name=VERSION::${version}"
 echo "VERSION::${version}"
 echo "::set-env name=IMAGE_TAG::${version}"
 echo "IMAGE_TAG::${version}"
-echo "::set-env name=GIT_REPOSITORY_LOWER::${git_repository_lower}"
-echo "GIT_REPOSITORY_LOWER::${git_repository_lower}"
+echo "::set-env name=GITHUB_REPOSITORY_LOWER::${github_repository_lower}"
+echo "GITHUB_REPOSITORY_LOWER::${github_repository_lower}"
 echo "::set-env name=GIT_TAG::${git_tag}"
 echo "GIT_TAG::${git_tag}"

--- a/build/ci/set_environment.sh
+++ b/build/ci/set_environment.sh
@@ -31,9 +31,13 @@ else
 fi
 git_tag="v${version}"
 
+git_repository_lower=$(echo "${GIT_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
+
 echo "::set-env name=VERSION::${version}"
 echo "VERSION::${version}"
 echo "::set-env name=IMAGE_TAG::${version}"
 echo "IMAGE_TAG::${version}"
+echo "::set-env name=GIT_REPOSITORY_LOWER::${git_repository_lower}"
+echo "GIT_REPOSITORY_LOWER::${git_repository_lower}"
 echo "::set-env name=GIT_TAG::${git_tag}"
 echo "GIT_TAG::${git_tag}"


### PR DESCRIPTION
This fixes the problem seen on https://github.com/SUSE/minibroker-integration-tests/runs/1068792165?check_suite_focus=true:
```
invalid argument "ghcr.io/SUSE/minibroker-integration-tests:0.1.0" for "-t, --tag" flag: invalid reference format: repository name must be lowercase
```