### PR TITLE
fix: script dir independent of git

### DIFF
--- a/deploy/minibroker.sh
+++ b/deploy/minibroker.sh
@@ -30,7 +30,7 @@ if ! helm version 1> /dev/null 2> /dev/null; then
   exit 1
 fi
 
-git_root="$(git rev-parse --show-toplevel)"
+script_dir="$(dirname "$(realpath "${BASH_SOURCE}")")"
 
 if [ -z "$(kubectl get namespace "${NAMESPACE}" --output name)" ]; then
   kubectl create namespace "${NAMESPACE}"
@@ -39,6 +39,6 @@ fi
 helm install "${RELEASE_NAME}" "${CHART_TARBALL}" \
   --wait \
   --namespace "${NAMESPACE}" \
-  ${SET_OVERRIDE_PARAMS:+--values "${git_root}/deploy/minibroker/override_params_values.yaml"} \
+  ${SET_OVERRIDE_PARAMS:+--values "${script_dir}/minibroker/override_params_values.yaml"} \
   --set "deployServiceCatalog=false" \
   --set "defaultNamespace=${NAMESPACE}"


### PR DESCRIPTION
Using dirname, realpath and BASH_SOURCE allows the script to be called without relying on the project being a git repository. This is useful for calling the script using the release tarball.