### PR TITLE
fix: set ghcr repository to cfcontainerizationbot

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
         description: |
           The image repository on GitHub Container Registry.
         required: true
-        default: cloudfoundry-incubator/minibroker-integration-tests
+        default: cfcontainerizationbot/minibroker-integration-tests
 
 jobs:
   release:


### PR DESCRIPTION
Releases have been published to the `cfcontainerizationbot` user registry so far. This commit changes it to be the default value.