### PR TITLE
Bump cf_create_service timeout from 5m to 10m

### DIFF
--- a/chart/mits/values.yaml
+++ b/chart/mits/values.yaml
@@ -51,4 +51,4 @@ config:
   timeouts:
     cf_push: 3m
     cf_start: 10m
-    cf_create_service: 5m
+    cf_create_service: 10m


### PR DESCRIPTION
On cap.suse.de caasp clusters, we have hit timeouts for RabbitMQ tests,
for both:
  should deploy and connect WITH extra provisioning parameters
  should deploy and connect WITHOUT extra provisioning parameters

See for example this [job](1).

They timeout at ~369 seconds (a bit more than 5 minutes), but sometimes they
deploy in 313 seconds, as a slow test (see [this other job](2))

Hence, increasing cf_create_service to 10m.

1: https://concourse.suse.dev/teams/main/pipelines/cap-pre-release-caasp/jobs/minibroker-integration-tests-diego-caasp4-sa/builds/1
2: https://concourse.suse.dev/teams/main/pipelines/cap-pre-release-caasp/jobs/minibroker-integration-tests-diego-caasp4-ha/builds/1#L5f409629:300