### PR TITLE
revert: "feat: bump cf-cli to v7"

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -15,7 +15,7 @@
 FROM golang:1.14 AS builder
 
 ARG DUMB_INIT_VERSION="1.2.2"
-ARG CF_CLI_VERSION="7.0.2"
+ARG CF_CLI_VERSION="6.51.0"
 
 RUN curl -L -o /usr/local/bin/dumb-init \
       "https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_amd64"
@@ -23,7 +23,7 @@ RUN chmod +x /usr/local/bin/dumb-init
 
 RUN go get -u github.com/onsi/ginkgo/ginkgo
 RUN curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" \
-      | tar zx -C /usr/local/bin cf cf7
+      | tar zx -C /usr/local/bin cf
 
 WORKDIR /minibroker-integration-tests
 # Copy the go.mod over so docker can cache the module downloads if possible.

--- a/mits/cases.go
+++ b/mits/cases.go
@@ -122,7 +122,7 @@ func SimpleAppAndService(
 	}()
 	workflowhelpers.AsUser(testSetup.AdminUserContext(), testSetup.ShortTimeout(), func() {
 		Expect(
-			cf.Cf("bind-security-group", securityGroupName, orgName, "--space", spaceName, "--lifecycle", "running").
+			cf.Cf("bind-security-group", securityGroupName, orgName, spaceName, "--lifecycle", "running").
 				Wait(testSetup.ShortTimeout()),
 		).To(Exit(0))
 	})


### PR DESCRIPTION
Reverts SUSE/minibroker-integration-tests#15 to be consistent on CAP 2.1 using cf-cli v6 across all projects.